### PR TITLE
add money_bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,7 @@ A curated list of examples, libraries and starter-kits for [Telegram](https://te
 + [confstat-bot](https://github.com/CubexX/confstat-bot) - Statistics for telegram groups https://stat.cubexx.xyz
 + [ns-bot](https://github.com/eigenein/ns-bot) - Unofficial journey planner for Nederlandse Spoorwegen trains
 
+### Ruby
+
++ [money_bot](https://github.com/m4rr/money_bot) - Currency converter bot with a well-designed UX.
+


### PR DESCRIPTION
This is an example of a Ruby-based bot setup. And this code is also running as [USDRUB_bot](https://telegram.me/USDRUB_bot).