### PR TITLE
Add Weight Goal Bot to Node.js examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Do you know Telegram Bot with open sources which is not mentioned in this list? 
 + [epub2mobiBot](https://epub2mobi.now.sh/_src) - Bot for converting books from EPUB to MOBI format. [`@epub2mobi_bot`](https://telegram.me/epub2mobi_bot)
 + [microgames](https://github.com/telegraf/microgames) - Telegram game platform example. [🐸 Play now](https://telegram.me/microgamesbot)
 + [Ver.bot](https://github.com/RPing/Ver.bot) - Subscribe projects, and notify you about new version release. [`@VbotVbot`](https://telegram.me/VbotVbot)
++ [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements. [`@my_weight_goal_bot`](https://t.me/my_weight_goal_bot)
 
 
 ### PHP

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Do you know Telegram Bot with open sources which is not mentioned in this list? 
 + [epub2mobiBot](https://epub2mobi.now.sh/_src) - Bot for converting books from EPUB to MOBI format. [`@epub2mobi_bot`](https://telegram.me/epub2mobi_bot)
 + [microgames](https://github.com/telegraf/microgames) - Telegram game platform example. [🐸 Play now](https://telegram.me/microgamesbot)
 + [Ver.bot](https://github.com/RPing/Ver.bot) - Subscribe projects, and notify you about new version release. [`@VbotVbot`](https://telegram.me/VbotVbot)
-+ [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Bilingual group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements. [`@my_weight_goal_bot`](https://t.me/my_weight_goal_bot)
++ [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [`@my_weight_goal_bot`](https://t.me/my_weight_goal_bot)
 
 
 ### PHP

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Do you know Telegram Bot with open sources which is not mentioned in this list? 
 + [epub2mobiBot](https://epub2mobi.now.sh/_src) - Bot for converting books from EPUB to MOBI format. [`@epub2mobi_bot`](https://telegram.me/epub2mobi_bot)
 + [microgames](https://github.com/telegraf/microgames) - Telegram game platform example. [🐸 Play now](https://telegram.me/microgamesbot)
 + [Ver.bot](https://github.com/RPing/Ver.bot) - Subscribe projects, and notify you about new version release. [`@VbotVbot`](https://telegram.me/VbotVbot)
-+ [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Group bot for photo-backed weekly weight goals, progress charts, reminders, and achievements in English, Russian, and Chinese. [`@my_weight_goal_bot`](https://t.me/my_weight_goal_bot)
++ [Weight Goal Bot](https://github.com/IgorShadurin/weight-telegram-bot) - Apache-2.0 group bot for photo-backed weekly weight goals, charts, reminders, 53 achievements, and nine natural localizations. [`@my_weight_goal_bot`](https://t.me/my_weight_goal_bot)
 
 
 ### PHP


### PR DESCRIPTION
## Summary

Adds [Weight Goal Bot](https://t.me/my_weight_goal_bot) ([source](https://github.com/IgorShadurin/weight-telegram-bot)) to the Node.js bot examples.

I maintain this Apache-2.0-licensed Telegram group bot. Its complete interface is naturally adapted for English, Russian, Chinese, Spanish, Portuguese, German, French, Japanese, and Indonesian; it uses photo-backed weigh-ins and provides weekly checkpoints, progress charts, reminders, and 53 achievements.

## Verification

- [x] The [live bot](https://t.me/my_weight_goal_bot) link resolves.
- [x] The [source repository](https://github.com/IgorShadurin/weight-telegram-bot) is public and licensed under Apache-2.0.
- [x] I searched this repository for an existing duplicate.
- [x] This change follows the existing source-first example format with a live Telegram link.